### PR TITLE
!Hotfix : Adding the "is_first_cmd" function and condition and initialize "prev_read_end"

### DIFF
--- a/Project_Dir/includes/executor.h
+++ b/Project_Dir/includes/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: junlee2 <junlee2@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: tyi <tyi@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/02 14:00:46 by junlee2           #+#    #+#             */
-/*   Updated: 2023/01/06 15:18:12 by junlee2          ###   ########seoul.kr  */
+/*   Updated: 2023/01/06 18:58:48 by tyi              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,5 +27,6 @@ int		wexitstatus(int status);
 void	pid_list_add(t_list *pidlist, pid_t pid);
 void	do_redirect(t_proc_data *proc_data);
 int		is_last_cmd(t_data *data, t_proc_data *proc_data);
+int		is_first_cmd(t_data *data, t_proc_data *proc_data);
 
 #endif

--- a/Project_Dir/srcs/executor/executor.c
+++ b/Project_Dir/srcs/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: junlee2 <junlee2@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: tyi <tyi@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/12/29 14:19:28 by junlee2           #+#    #+#             */
-/*   Updated: 2023/01/06 17:26:18 by jincpark         ###   ########.fr       */
+/*   Updated: 2023/01/06 18:59:17 by tyi              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,8 @@ pid_t	do_fork(t_data *data, t_proc_data *proc_data)
 	int			cur_write_end;
 	static int	prev_read_end;
 
+	if (is_first_cmd(data, proc_data))
+		prev_read_end = 0;
 	if (is_last_cmd(data, proc_data))
 		cur_write_end = STDOUT_FILENO;
 	else


### PR DESCRIPTION
When a new command line was executed, the static variable "prev_read_end" was not initialized ("echo -n | cat" x 3). So, updated it by adding the "is_first_cmd" function and condition. - jincpark tyi