### PR TITLE
!Hotfix : When only "ctrl+d" input makes data.line ==0, must exit minisehll. So update, is_line_empty option exit func

### DIFF
--- a/Project_Dir/srcs/util/etc.c
+++ b/Project_Dir/srcs/util/etc.c
@@ -6,7 +6,7 @@
 /*   By: tyi <tyi@student.42seoul.kr>               +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/07 18:34:38 by jincpark          #+#    #+#             */
-/*   Updated: 2023/01/07 23:38:03 by tyi              ###   ########.fr       */
+/*   Updated: 2023/01/08 10:18:13 by tyi              ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 #include "../../includes/util.h"
 #include "../../includes/envp.h"
 #include "../../includes/builtin.h"
+
+extern int		g_last_exit_status;
 
 void	init_data(t_data *data, char **envp)
 {
@@ -43,7 +45,7 @@ int	is_line_empty(char *line)
 	char	*line_cp;
 
 	if (line == NULL)
-		return (1);
+		exit (g_last_exit_status);
 	line_cp = line;
 	while (*line && ((*line >= 9 && *line <= 13) || *line == 32))
 		line++;


### PR DESCRIPTION
터미널에 ctrl + d만 들어왔을 때, exit (last_exit_status)로 종료하게 해놓았습니다. data_free 는 진행하지 않았습니다. 